### PR TITLE
Fix syntax error in card API

### DIFF
--- a/lib/3llo/api/card.rb
+++ b/lib/3llo/api/card.rb
@@ -39,7 +39,7 @@ module Tr3llo
         )
       end
 
-      def create(name:, description:, list_id:)
+      def create(name, description, list_id)
         JSON.parse(
           client.post(
             "/cards",

--- a/lib/3llo/commands/card/add.rb
+++ b/lib/3llo/commands/card/add.rb
@@ -26,12 +26,9 @@ module Tr3llo
 
         attr_reader :board_id
 
+        
         def create_card!(name, description, list_id)
-          API::Card.create(
-            name: name,
-            description: description,
-            list_id: list_id
-          )
+          API::Card.create(name, description, list_id)
         end
 
         def load_lists


### PR DESCRIPTION
This change is in response to an [error](https://github.com/qcam/3llo/files/1293193/output.txt) I received when trying to run the software.