### PR TITLE
Improve self-documentation of 3llo by adding a `--help` switch, show errors without confusing tracebacks

### DIFF
--- a/bin/3llo
+++ b/bin/3llo
@@ -10,10 +10,26 @@ $container.register(:api_client, Tr3llo::HTTP::Client)
 prompt = TTY::Prompt.new
 $container.register(:interface, Tr3llo::Interface.new(prompt, $stdout))
 
+def print_help(stripped = false)
+  Tr3llo::Presenter::HelpPresenter
+    .new($container.resolve(:interface), stripped)
+    .print!
+end
+
+if ARGV.size == 1 && (ARGV[0] == "-h" || ARGV[0] == "--help")
+  print_help(true)
+  exit
+end
+
 configuration = Tr3llo::Configuration.new
-configuration.user_id = ENV.fetch('TRELLO_USER') { raise "Have you set TRELLO_USER?" }
-configuration.api_key = ENV.fetch('TRELLO_KEY') { raise "Have you set TRELLO_KEY?" }
-configuration.api_token = ENV.fetch('TRELLO_TOKEN') { raise "Have you set TRELLO_TOKEN?" }
+begin
+  configuration.user_id = ENV.fetch('TRELLO_USER') { raise "Have you set TRELLO_USER?" }
+  configuration.api_key = ENV.fetch('TRELLO_KEY') { raise "Have you set TRELLO_KEY?" }
+  configuration.api_token = ENV.fetch('TRELLO_TOKEN') { raise "Have you set TRELLO_TOKEN?" }
+rescue => error
+  abort "Invalid configuration: \e[1m#{error.message}".colorize(31)
+end
+
 configuration.finalize!
 
 $container.register(
@@ -24,8 +40,6 @@ $container.register(
 user = Tr3llo::API::User.find($container.resolve(:configuration).user_id)
 $container.register(:user, user)
 
-Tr3llo::Presenter::HelpPresenter
-  .new($container.resolve(:interface))
-  .print!
+print_help(false)
 
 Tr3llo::Controller.new.start

--- a/lib/3llo/presenter/help.rb
+++ b/lib/3llo/presenter/help.rb
@@ -1,13 +1,18 @@
 module Tr3llo
   module Presenter
     class HelpPresenter
-      def initialize(interface)
+      def initialize(interface, stripped = false)
         @interface = interface
+        @stripped = stripped
       end
 
       def print!
         interface.print_frame do
-          interface.puts menu_text
+          text = menu_text(@stripped)
+          if @stripped
+            text = text.split("\n").map(&:lstrip).drop(1).join("\n")
+          end
+          interface.puts text
         end
       end
 
@@ -15,10 +20,16 @@ module Tr3llo
 
       attr_reader :interface
 
-      def menu_text
-        %q{
+      def menu_text(cli_help = false)
+        cli_help_text = %q{
+          This is an interactive program for trello cards. To start, you
+          need to set `TRELLO_USER`, `TRELL_KEY` and `TRELLO_TOKEN` to access
+          your account. After that, the following commands are available in interactive
+          mode:
+        }
+        %Q{
     3llo - CLI for Trello
-
+    #{if cli_help then cli_help_text end}
     Usage:
     board list                   - Show list of board
     board select                 - Select board


### PR DESCRIPTION
This change adds a `--help` switch which prints the help text in an unindented version to make the program self-documenting. Also added a `begin->rescue` block around the environment validation to avoid printing confusing tracebacks with errors when invoking the program without any arguments the first time.