### PR TITLE
A workaround for piped input

### DIFF
--- a/lib/3llo/command_factory.rb
+++ b/lib/3llo/command_factory.rb
@@ -9,7 +9,7 @@ require '3llo/commands/error'
 module Tr3llo
   class CommandFactory
     def initialize(command_buffer)
-      @command_buffer = command_buffer
+      @command_buffer = command_buffer.nil? ? "exit" : command_buffer
     end
 
     def factory


### PR DESCRIPTION
Hi there!

First of all: this is a cool project, thank you! Unfortunately once I tried to pipe some predefined commands into it as part of a script, it broke:

```bash
echo "board list" | 3llo
```

Because apparently piping also emits an `EOF` character, which is not handled by 3llo. In case this happens I simply replaced it with an `exit` command, but maybe you want to change the behavior for 3llo to keep running instead. I don't know how to do this though.

That's it, would be cool if we could get it to accept commands through piped input. Thanks!