### PR TITLE
Colorize all possible Trello label color names

### DIFF
--- a/lib/core_ext.rb
+++ b/lib/core_ext.rb
@@ -1,12 +1,23 @@
 class String
+
+  # Trello label color names:
+  #   https://trello.com/c/ZAvI05TG/94-label-color-names-sticker-names
+  #
+  # Terminal color codes:
+  #   https://www.tldp.org/HOWTO/Bash-Prompt-HOWTO/x329.html
   COLOR = {
     red: 31,
+    pink: 31,
     blue: 34,
     green: 32,
+    lime: 32,
     black: 37,
+    white: 37,
     purple: 35,
     yellow: 33,
-    orange: 33
+    orange: 33,
+    cyan: 36,
+    sky: 36
   }.freeze
 
   def colorize(*code)


### PR DESCRIPTION
A future commit could map "pink", "lime", and "sky" to the ANSI bright
equivalent codes (e.g. '\e[1;34m' for light blue vs '\e[34m' for blue).