### PR TITLE
Allow user to specify board as a cli flag

### DIFF
--- a/bin/3llo
+++ b/bin/3llo
@@ -4,6 +4,7 @@ $:.unshift File.expand_path("../../lib", __FILE__)
 require "3llo"
 require 'container'
 require 'tty-prompt'
+require 'optparse'
 
 $container = Container.new
 $container.register(:api_client, Tr3llo::HTTP::Client)
@@ -16,10 +17,20 @@ def print_help(stripped = false)
     .print!
 end
 
-if ARGV.size == 1 && (ARGV[0] == "-h" || ARGV[0] == "--help")
-  print_help(true)
-  exit
-end
+options = {}
+OptionParser.new do |opts|
+
+  opts.on("-h", "--help", "Display this help message") do
+    print_help(true)
+    puts opts
+    exit
+  end
+
+  opts.on("-b", "--board BOARD", "Set default board") do |b|
+    options[:board] = b
+  end
+
+end.parse!
 
 configuration = Tr3llo::Configuration.new
 begin
@@ -40,6 +51,10 @@ $container.register(
 user = Tr3llo::API::User.find($container.resolve(:configuration).user_id)
 $container.register(:user, user)
 
+if options.key?(:board)
+  board = Tr3llo::API::Board.find(options[:board])
+  $container.register(:board, board)
+end
 print_help(false)
 
 Tr3llo::Controller.new.start


### PR DESCRIPTION
Allow user to specify board as a cli flag. Related to https://github.com/qcam/3llo/issues/37

This allows invocation like:

`3llo -b <board_id>`

Or

```
3llo -b <board id> <<<"card list
> exit"
```

Which can be used for batch jobs. If we like this option handling it seems like we could unify the ENV vars and the cli flags more. Its been a while for me ruby wise but happy to change this however just let me know.