### PR TITLE
Remove redundant whitespaces

### DIFF
--- a/lib/3llo/controller.rb
+++ b/lib/3llo/controller.rb
@@ -5,7 +5,7 @@ module Tr3llo
     extend self
 
     def start(init_command)
-      Readline.completion_append_character = "   "
+      Readline.completion_append_character = " "
       Readline.completion_proc = lambda { |buffer|
         Command.generate_suggestions(buffer, Readline.line_buffer)
       }


### PR DESCRIPTION
I just found `Readline.completion_append_character` attribute only take the first character value, so I opened the PR to remove some whitespaces for the beauty of codes.