### PR TITLE
Update Rubocop file for version 0.80

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -57,8 +57,14 @@ Security/JSONLoad:
 Style/Alias:
   EnforcedStyle: prefer_alias
 
-Style/BracesAroundHashParameters:
-  Enabled: false
+Style/HashEachMethods:
+  Enabled: true
+
+Style/HashTransformKeys:
+  Enabled: true
+
+Style/HashTransformValues:
+  Enabled: true
 
 Style/DefWithParentheses:
   Enabled: false


### PR DESCRIPTION
- `BracesAroundHashParameters` style has been removed since verison 0.80. We need to change it to prevent CI crashes.

- `HashEachMethods ` style helps you write a clean code while looping Hashes, instead of writing `hash.keys.each`, sure that you'll more prefer `hash.each_key`.

- `HashTransformKeys / HashTransformValues` styles help you pass less argument on the block since Ruby 2.5. 
E.x: Let's say if we want to change the hash key into String: `{ one: 1, two: 2 }` =>  `{ "one": 1, "two": 2 }`. Before version 2.5, we did use the complex `each_with_object` method, `{ one: 1, two: 2 }.each_with_object({}) { |(k, v), h| h[k.to_s] = v }`, now we have had `transform_values` method and call it like that `{ one: 1, two: 2 }.transform_keys { |k| k.to_s }`.