### PR TITLE
Add support for exiting using Ctrl+D combination

### DIFF
--- a/lib/3llo/controller.rb
+++ b/lib/3llo/controller.rb
@@ -21,6 +21,8 @@ module Tr3llo
       loop do
         command_buffer = Readline.readline("\e[15;48;5;27m 3llo \e[0m > ", true)
 
+        Command::Exit.execute() if command_buffer.nil?
+
         execute_command!(command_buffer)
       end
     rescue Interrupt


### PR DESCRIPTION
A method I often use to exit a Ruby REPL is using Ctrl+D keys combined.
Readline however will output after reading this EOF as nil which raises
exception. Adding this support will gracefully exit 3llo with Ctrl+D.