### PR TITLE
Implement list add command

### DIFF
--- a/lib/3llo/api/list.rb
+++ b/lib/3llo/api/list.rb
@@ -23,6 +23,16 @@ module Tr3llo
         client.post(req_path, {}, {})
       end
 
+      def create(name, board_id)
+        req_path = Utils.build_req_path("/lists")
+        payload = {
+          "name" => name,
+          "idBoard" => board_id
+        }
+
+        client.post(req_path, {}, payload)
+      end
+
       private
 
       def make_struct(payload)

--- a/lib/3llo/command.rb
+++ b/lib/3llo/command.rb
@@ -17,7 +17,7 @@ module Tr3llo
     def generate_suggestions(buffer, command_buffer)
       commands = {
         "board" => ["list", "select"],
-        "list" => %w[list cards archive-cards],
+        "list" => %w[list add cards archive-cards],
         "card" => %w[
           list show add edit archive list-mine move
           comment comments self-assign assign

--- a/lib/3llo/command/list.rb
+++ b/lib/3llo/command/list.rb
@@ -1,4 +1,5 @@
 require "3llo/command/list/list"
+require "3llo/command/list/add"
 require "3llo/command/list/cards"
 require "3llo/command/list/invalid"
 require "3llo/command/list/archive_cards"
@@ -14,6 +15,10 @@ module Tr3llo
           board = Application.fetch_board!()
 
           Command::List::List.execute(board[:id])
+        when "add"
+          board = Application.fetch_board!()
+
+          Command::List::Add.execute(board[:id])
         when "cards"
           list_key, = args
           Utils.assert_string!(list_key, "list key is missing")

--- a/lib/3llo/command/list/add.rb
+++ b/lib/3llo/command/list/add.rb
@@ -1,0 +1,21 @@
+module Tr3llo
+  module Command
+    module List
+      module Add
+        extend self
+
+        def execute(board_id)
+          interface = Application.fetch_interface!()
+
+          interface.print_frame do
+            name = interface.input.ask("Name:", required: true)
+
+            API::List.create(name, board_id)
+
+            interface.puts("List has been created.")
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/3llo/view/list/help.rb
+++ b/lib/3llo/view/list/help.rb
@@ -9,6 +9,7 @@ module Tr3llo
           #{Utils.format_bold("# Available list commands:")}
 
           list list                 - Show all lists
+          list add                  - Create a list
           list cards <key>          - Show all cards in list
           list archive-cards <key>  - Archive all cards in list
           TEMPLATE

--- a/spec/3llo/command/list/add_spec.rb
+++ b/spec/3llo/command/list/add_spec.rb
@@ -1,0 +1,39 @@
+require "spec_helper"
+
+describe "list add", type: :integration do
+  include IntegrationSpecHelper
+
+  before { $application = build_container() }
+  after { $application = nil }
+
+  it "creates a new list" do
+    board_id = "board:1"
+
+    select_board($application, make_board(board_id))
+
+    make_client_mock($application) do |client_mock|
+      expect(client_mock).to(
+        receive(:post)
+          .with(
+            req_path("/lists"),
+            _headers = {},
+            _payload = {
+              "name" => "List 1",
+              "idBoard" => board_id
+            }
+          )
+          .and_return({})
+      )
+    end
+
+    interface = make_interface($application) do |input, _output|
+      expect(input).to receive(:ask).with("Name:", required: true).and_return("List 1")
+    end
+
+    execute_command("list add")
+
+    output_string = interface.output.string
+
+    expect(output_string).to match("List has been created.")
+  end
+end

--- a/spec/3llo/command_spec.rb
+++ b/spec/3llo/command_spec.rb
@@ -11,8 +11,8 @@ describe Tr3llo::Command do
       assert_suggestions("l", "board l", ["list"])
 
       assert_suggestions("l", "l", ["list", "label"])
-      assert_suggestions("", "list ", %w[list cards archive-cards])
-      assert_suggestions("a", "list a", ["archive-cards"])
+      assert_suggestions("", "list ", %w[list add cards archive-cards])
+      assert_suggestions("a", "list a", ["add", "archive-cards"])
       assert_suggestions("ca", "list ca", ["cards"])
       assert_suggestions("l", "list l", ["list"])
 


### PR DESCRIPTION
# Description

Added the 'list add' command and updated the interface to show the `list add` option

# Related Issues
https://github.com/qcam/3llo/issues/68


# Manual Testing Plan
Did a manual test on the CLI after rebuilding gem 

Added an integration spec for `list add` but I am unfamiliar with ruby and don't know how to set up the testing environment


