### PR TITLE
feat(init): Ability to run many command

### DIFF
--- a/lib/3llo/controller.rb
+++ b/lib/3llo/controller.rb
@@ -13,9 +13,11 @@ module Tr3llo
       interface = Application.fetch_interface!()
 
       if init_command && init_command != ""
-        interface.puts("Executing " + Utils.format_highlight(init_command) + " command")
-
-        execute_command!(init_command)
+        init_commands = init_command.split(";")
+        init_commands.each do |cmd|
+          interface.puts("Executing " + Utils.format_highlight(cmd) + " command")
+          execute_command!(cmd)
+        end
       end
 
       loop do


### PR DESCRIPTION
Add the ability to specify many command with the `--init` startup flag.
Each init command should be separated by a semicolon (;).

Thank you for your work

Regards